### PR TITLE
Link Russian translation with base repo

### DIFF
--- a/basics/index.yml
+++ b/basics/index.yml
@@ -1,0 +1,3 @@
+title: D's Basics
+ordering:
+- alias-strings

--- a/index.yml
+++ b/index.yml
@@ -1,0 +1,6 @@
+title: Dlang Tour
+start: welcome/welcome-to-d
+repo: dlang-tour/english
+ordering:
+- welcome
+- basics

--- a/welcome/index.yml
+++ b/welcome/index.yml
@@ -1,0 +1,3 @@
+title: Welcome
+ordering:
+- welcome-to-d

--- a/welcome/welcome-to-d.md
+++ b/welcome/welcome-to-d.md
@@ -1,0 +1,3 @@
+# Welcome to D
+
+(to be filled)


### PR DESCRIPTION
A bit of maintenance work. I [linked](https://github.com/stonemaster/dlang-tour/pull/481) the russian submodule with the main repo and for the pages to be rendered, they need to be listed in the corresponding `index.yml`. 
(there is no need to add them to the config file during the translation - it will create unnecessary conflicts)

Moreover a "root" config is needed that links the enabled chapters and contains a couple of settings like the landing page.

(I used the English titles as I don't speak Russian)
