### PR TITLE
fix comments in basics/alias-strings

### DIFF
--- a/basics/alias-strings.md
+++ b/basics/alias-strings.md
@@ -50,8 +50,8 @@
 
 Уменьшить количество трудоёмкого ручного экранирования можно, определяя raw-строки с использованием обратных апострофов (`` ` ... ` ``), либо префикса r(aw) (`r" ... "`).
 
-    string raw  =  `raw "string"`;\\raw "string"
-    string raw2 = r"raw "string"";\\raw "string"
+    string raw  =  `raw "string"`; // raw "string"
+    string raw2 = r"raw "string""; // raw "string"
 
 ### Подробнее
 


### PR DESCRIPTION
I don't speak (much) Russian, but I fixed that mistake in the English version a while ago ;-)
